### PR TITLE
ISSUE#56 - Página para diretoria criada

### DIFF
--- a/public/posts/diretorias/diretoria.json
+++ b/public/posts/diretorias/diretoria.json
@@ -1,0 +1,16 @@
+{
+    "data": "2022-01-16T21:35:22.297Z",
+    "titulo": "Chapa teste 2022",
+    "banner": "images/borboleta_com_frase.jpg",
+    "description": "A chapa teste 2022 é a **chapa** teste!",
+    "active": true,
+    "integrantes": [
+      {
+        "name": "Fulana",
+        "role": "Presidente",
+        "photo": "images/diretorias/diretoriaAvatar01.png",
+        "bio": "Fulana é presidente desde o dia que o arquivo .json foi criado.",
+        "email": "fulana@email.com"
+      }
+    ]
+  }

--- a/src/components/Diretorias/index.js
+++ b/src/components/Diretorias/index.js
@@ -1,22 +1,26 @@
-import React from 'react';
-import { Avatar, Box, Card, CardActionArea, CardActions, CardContent, CardHeader, Container, Grid, Typography } from '@mui/material';
-import Image from 'next/image'
-import { Email, Phone } from '@mui/icons-material';
-import { useRouter } from 'next/router';
+import React from "react";
+import {
+  Avatar,
+  Box,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  Container,
+  Grid,
+  Typography,
+} from "@mui/material";
+import Image from "next/image";
+import { Email, Phone } from "@mui/icons-material";
+import { useRouter } from "next/router";
 
-const CustomTitle = ({
-  children
-}) => (
-  <Typography
-    variant="h3" sx={{ mb: 2 }}>
+const CustomTitle = ({ children, onClick }) => (
+  <Typography variant="h3" sx={{ mb: 2, cursor: "pointer" }} onClick={onClick}>
     {children}
   </Typography>
-)
+);
 
-const CustomCard = ({
-  diretoria,
-  ...rest
-}) => {
+const CustomCard = ({ diretoria, ...rest }) => {
   const router = useRouter();
 
   return (
@@ -25,9 +29,10 @@ const CustomCard = ({
         minHeight: "250px",
         height: 1,
         padding: 1,
-        borderRadius: 2
+        borderRadius: 2,
       }}
-      {...rest}>
+      {...rest}
+    >
       <CardHeader
         title={diretoria.role}
         subheader={diretoria.name}
@@ -36,118 +41,109 @@ const CustomCard = ({
             <Image
               src={`/${diretoria.photo}`}
               alt={diretoria.role + " - Avatar"}
-              layout="fill" />
+              layout="fill"
+            />
           </Avatar>
         }
         sx={{
-          height: "100px"
+          height: "100px",
         }}
       />
       <CardContent sx={{ height: "180px" }}>
-        <Typography>
-          {diretoria.bio}
-        </Typography>
+        <Typography>{diretoria.bio}</Typography>
       </CardContent>
       <CardActions>
         <Box display="flex" flexDirection="column-reverse" p={1}>
-          {
-            diretoria.phone &&
+          {diretoria.phone && (
             <>
               <Box display="flex" flexDirection="row" pt={2}>
                 <Phone />
                 <Typography
                   sx={{
-                    ml: 1.5
-                  }}>
+                    ml: 1.5,
+                  }}
+                >
                   {diretoria.phone || ""}
                 </Typography>
               </Box>
             </>
-          }
-          {
-            diretoria.email &&
+          )}
+          {diretoria.email && (
             <>
               <Box display="flex" flexDirection="row" pt={2}>
                 <Email />
                 <Typography
                   sx={{
-                    ml: 1.5
-                  }}>
+                    ml: 1.5,
+                  }}
+                >
                   {diretoria.email || ""}
                 </Typography>
               </Box>
             </>
-          }
+          )}
         </Box>
       </CardActions>
     </Card>
-  )
-}
+  );
+};
 
-const DiretoriasGridView = ({
-  diretoria
-}) => (
-  <Box>
-    <CustomTitle>{diretoria.titulo}</CustomTitle>
-    <Grid
-      container
-      spacing={3}>
-      {
-        diretoria.integrantes.map(d => (
-          <Grid
-            item
-            key={d.id}
-            xs="12"
-            md="6"
-            lg="4">
-            <CustomCard diretoria={d} />
-          </Grid>
-        ))
-      }
-    </Grid>
-  </Box>
-);
-
-const DiretoriasArchiveSwiper = ({
-  archive
-}) => {
-
+const DiretoriasGridView = ({ diretoria }) => {
+  const router = useRouter();
   return (
-    <Box sx={{
-      my: 4
-    }}>
+    <>
+      <Box>
+        <CustomTitle
+          onClick={() => router.push(`/diretorias/${diretoria.fileName}`)}
+        >
+          {diretoria.titulo}
+        </CustomTitle>
+        <Grid container spacing={3}>
+          {diretoria.integrantes.map((d) => (
+            <Grid item key={d.id} xs="12" md="6" lg="4">
+              <CustomCard diretoria={d} />
+            </Grid>
+          ))}
+        </Grid>
+      </Box>
+    </>
+  );
+};
+
+const DiretoriasArchiveSwiper = ({ archive }) => {
+  return (
+    <Box
+      sx={{
+        my: 4,
+      }}
+    >
       <Container>
         <CustomTitle>Diretorias Passadas</CustomTitle>
       </Container>
 
-      <Container
-        maxWidth="false">
+      <Container maxWidth="false">
         <Box
           display="flex"
           sx={{
-            "overflow-x": "scroll"
+            "overflow-x": "scroll",
           }}
         >
-          {
-            archive.map(d => (
-              <Box
-                key={d.titulo}
-                minWidth="300px"
-                sx={{
-                  mr: 2,
-                  mb: 2
-                }}>
-                <CustomCard diretoria={d.content[0]} />
-              </Box>
-            ))
-          }
+          {archive.map((d) => (
+            <Box
+              key={d.titulo}
+              minWidth="300px"
+              sx={{
+                mr: 2,
+                mb: 2,
+              }}
+            >
+              <CustomCard diretoria={d.content[0]} />
+            </Box>
+          ))}
         </Box>
       </Container>
-    </Box >
-  )
+    </Box>
+  );
 };
 
-export {
-  DiretoriasGridView,
-  DiretoriasArchiveSwiper
-}
+export { DiretoriasGridView, DiretoriasArchiveSwiper };

--- a/src/pages/diretorias/[fileName].js
+++ b/src/pages/diretorias/[fileName].js
@@ -8,7 +8,7 @@ import {
   Typography,
 } from "@mui/material";
 import { handleJSONfile, handleJSONfiles } from "../../../utils/postHandler";
-import moment from 'moment-timezone';
+import moment from "moment-timezone";
 
 export function getStaticPaths() {
   const diretorias = handleJSONfiles("./public/posts/diretorias");
@@ -24,31 +24,23 @@ export function getStaticPaths() {
 
 export function getStaticProps(context) {
   const fileName = context.params.fileName;
-  const diretoria = handleJSONfile(`./public/posts/diretorias/${fileName}.json`);
+  const diretoria = handleJSONfile(
+    `./public/posts/diretorias/${fileName}.json`
+  );
 
   return {
     props: { diretoria },
   };
 }
 
-const Diretoria = ({
-  diretoria
-}) => {
-  const {
-    role: title,
-    photo: banner,
-    bio: content,
-    author,
-  } = diretoria;
+const Diretoria = ({ diretoria }) => {
+  const { titulo: title, banner: banner, description: content } = diretoria;
 
   return (
     <Container>
       <Card>
         <CardMedia component="img" height="280" src={"/" + banner} alt="" />
         <CardContent>
-          <Typography gutterBottom variant="body2" component="div">
-            Por: {author}
-          </Typography>
           <Typography gutterBottom variant="h4" component="div">
             {title}
           </Typography>

--- a/src/pages/diretorias/index.js
+++ b/src/pages/diretorias/index.js
@@ -1,16 +1,11 @@
+import { Container } from "@mui/material";
 import {
-  Avatar,
-  Card,
-  CardContent,
-  CardHeader,
-  Container,
-  Grid,
-  Typography
-} from '@mui/material';
-import { DiretoriasArchiveSwiper, DiretoriasGridView } from 'components/Diretorias';
-import PageTitle from 'components/PageTitle';
-import React, { useMemo } from 'react';
-import { handleJSONfiles } from '../../../utils/postHandler';
+  DiretoriasArchiveSwiper,
+  DiretoriasGridView,
+} from "components/Diretorias";
+import PageTitle from "components/PageTitle";
+import React, { useMemo } from "react";
+import { handleJSONfiles } from "../../../utils/postHandler";
 
 export function getStaticProps() {
   const diretorias = handleJSONfiles("./public/posts/diretorias");
@@ -20,12 +15,14 @@ export function getStaticProps() {
   };
 }
 
-const Diretorias = ({
-  diretorias = [],
-}) => {
-  const sortedDiretorias = useMemo(() => diretorias.sort(function (a, b) {
-    return new Date(b.data) - new Date(a.data);
-  }), [diretorias])
+const Diretorias = ({ diretorias = [] }) => {
+  const sortedDiretorias = useMemo(
+    () =>
+      diretorias.sort(function (a, b) {
+        return new Date(b.data) - new Date(a.data);
+      }),
+    [diretorias]
+  );
 
   return (
     <>
@@ -33,16 +30,15 @@ const Diretorias = ({
       <Container
         sx={{
           my: 6,
-        }}>
-        {
-          !!sortedDiretorias.length &&
+        }}
+      >
+        {!!sortedDiretorias.length && (
           <DiretoriasGridView diretoria={sortedDiretorias[0]} />
-        }
+        )}
       </Container>
       {/* <DiretoriasArchiveSwiper archive={sortedDiretorias.slice(1, sortedDiretorias.length) || []} /> */}
     </>
-  )
-}
+  );
+};
 
-
-export default Diretorias
+export default Diretorias;


### PR DESCRIPTION
### Resumo
Para acessar a página, o usuário deve clicar no título da diretoria (talvez seja melhor em um outro lugar?)

![image](https://user-images.githubusercontent.com/50248007/152704195-806588c6-946c-4260-81dc-356eb5566029.png)

Dessa forma, adicionei para o componente `CustomTitle` uma prop de `onClick` e setei `cursor: "pointer"`. 

A página da diretoria é composta pelo banner da diretoria, o seu título e descrição. O arquivo json que usei para fazer os testes está no commit. 

### Resultados
![image](https://user-images.githubusercontent.com/50248007/152704155-554ef4c3-bd06-426a-ade2-88d946eeb445.png)


